### PR TITLE
Update resume Nudgeathon spelling

### DIFF
--- a/app/resume/page.mdx
+++ b/app/resume/page.mdx
@@ -110,7 +110,7 @@ Find me at:
 
 - Distinction Average (5.76 GPA, 77.98 WAM).
 - Drafted for publication: Causal effect of amendments to the Gambling Machine Act (NSW) on domestic households by use of a difference-in-difference framework.
-- Nudgethon 2022 UTS representative: Representing UTS in the annual national Nudgethon event hosted by QUT Centre for Behavioural Economics, Society and Technology (BEST Centre) & the ANU Crawford School of Public Policy.
+- Nudgeathon 2022 UTS representative: Representing UTS in the annual national Nudgeathon event hosted by QUT Centre for Behavioural Economics, Society and Technology (BEST Centre) & the ANU Crawford School of Public Policy.
 - Mentor for first-year economics students.
 </WorkplaceBanner>
 


### PR DESCRIPTION
## Summary
- fix Nudgeathon misspelling in resume page

## Testing
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844e49a557483259f3f89a12cd76504